### PR TITLE
Added two new options that speed up compilation

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -137,27 +137,29 @@ TESTS = $(check_PROGRAMS)
 noinst_PROGRAMS =
 
 if DILL_SOCKETS
+if DILL_TUTORIAL
 noinst_PROGRAMS += \
-    tutorial/basics/step1 \
-    tutorial/basics/step2 \
-    tutorial/basics/step3 \
-    tutorial/basics/step4 \
-    tutorial/basics/step5 \
-    tutorial/protocol/step1 \
-    tutorial/protocol/step2 \
-    tutorial/protocol/step3 \
-    tutorial/protocol/step4 \
-    tutorial/protocol/step5 \
-    tutorial/protocol/step6 \
-    tutorial/protocol/step7 \
-    tutorial/protocol/step8 \
-    tutorial/protocol/step9
+tutorial/basics/step1 \
+tutorial/basics/step2 \
+tutorial/basics/step3 \
+tutorial/basics/step4 \
+tutorial/basics/step5 \
+tutorial/protocol/step1 \
+tutorial/protocol/step2 \
+tutorial/protocol/step3 \
+tutorial/protocol/step4 \
+tutorial/protocol/step5 \
+tutorial/protocol/step6 \
+tutorial/protocol/step7 \
+tutorial/protocol/step8 \
+tutorial/protocol/step9
+endif
 endif
 
 ################################################################################
 #  performance tests                                                           #
 ################################################################################
-
+if DILL_PERF_TEST
 noinst_PROGRAMS += \
     perf/go \
     perf/ctxswitch \
@@ -166,7 +168,7 @@ noinst_PROGRAMS += \
     perf/hdone \
     perf/whispers \
     perf/timer
-
+endif
 ################################################################################
 #  manpage documentation generation                                            #
 ################################################################################

--- a/configure.ac
+++ b/configure.ac
@@ -142,6 +142,30 @@ else
 fi
 
 ################################################################################
+# --disable-tutorial                                                           #
+################################################################################
+
+AC_ARG_ENABLE([tutorial], [AS_HELP_STRING([--disable-tutorial],
+    [Disable tutorial compilation [default=no]])])
+if test "x$enable_tutorial" = "xno"; then
+   AM_CONDITIONAL([DILL_TUTORIAL], false)
+else
+   AM_CONDITIONAL([DILL_TUTORIAL], true)
+fi
+
+################################################################################
+# --disable-perf-tests                                                         #
+################################################################################
+
+AC_ARG_ENABLE([perf-tests], [AS_HELP_STRING([--disable-perf-tests],
+    [Disable performance test software compilation [default=no]])])
+if test "x$enable_perf_tests" = "xno"; then
+   AM_CONDITIONAL([DILL_PERF_TEST], false)
+else
+   AM_CONDITIONAL([DILL_PERF_TEST], true)
+fi
+
+################################################################################
 #  --disable-sockets                                                           #
 ################################################################################
 


### PR DESCRIPTION
The original compilation process generates a tutorial and performance tests. The first is used for educational purposes and the second for unit testing solely. Both types of binaries are not installed with compiling the library for deployment, but they are compiled and that increase a lot the compilation time.

## Proposed Solution

- I have added the _configure_ parameter `--disable-tutorial` in order to avoid compiling tutorial source code.
- I have also added the _configure_ parameter `--disable-perf-tests` in order to avoid compiling performance tests.

So, when configuring the new package for deployment, the following should be used:

`./configure --disable-tutorial --disable-perf-tests`

So, for automated installations, it will decrease the time necessary to configure and compile the whole package.