### PR TITLE
Fix partial reads

### DIFF
--- a/fd.c
+++ b/fd.c
@@ -265,6 +265,8 @@ ssize_t fd_recv(int s, struct fd_rxbuf *rxbuf, struct iolist *first,
                 if(errno == EPIPE) errno = ECONNRESET;
                 return -1;
             }
+            /* If we have read data return it immediately */
+            if (read > 0) return read;
             /* Wait for more data. */
             int rc = fdin(s, deadline);
             if(dill_slow(rc < 0)) return -1;


### PR DESCRIPTION
Partial reads use an internal buffer that is filled and drained into the requestors buffer. If some data is drained we still wait on the file descriptor even though no more data may arrive until the requestor responds (e.g. last chunk of HTTP was drained from the rxbuf here but we still wait for more data though we need to send a response first likely!)